### PR TITLE
Fix datepicker date-format as yy-mm-dd

### DIFF
--- a/common/js/plugins/ui/rx_datepicker.js
+++ b/common/js/plugins/ui/rx_datepicker.js
@@ -3,5 +3,11 @@
  * @author MinSoo Kim <misol.kr@gmail.com>
  **/
 if(typeof current_lang !== "undefined" && current_lang !== 'en') {
-	jQuery.getScript(request_uri + "./common/js/plugins/ui/i18n/datepicker-"+ current_lang.replace("jp", "ja") +".js");
+	jQuery.getScript(request_uri + "./common/js/plugins/ui/i18n/datepicker-"+ current_lang.replace("jp", "ja") +".js", function() {
+		var default_option = {
+			dateFormat:'yy-mm-dd'
+		};
+		jQuery.extend(jQuery.datepicker.regional[current_lang.replace("jp", "ja")],default_option);
+		jQuery.datepicker.setDefaults( datepicker.regional[current_lang.replace("jp", "ja")] );
+	});
 }

--- a/modules/editor/components/poll_maker/tpl/popup.html
+++ b/modules/editor/components/poll_maker/tpl/popup.html
@@ -20,7 +20,7 @@
 			<label for="" class="x_control-label">{$lang->poll_stop_date}</label>
 			<div class="x_controls">
 				<input type="hidden" name="stop_date" id="stop_date" value="{date('Ymd',time()+60*60*24*30)}" />
-				<input type="date" class="inputDate" min="{date('Y-m-d',time())}"  max="{date('Y-m-d',strtotime('+10 years'))}" onchange="jQuery('#stop_date').val(this.value.replace(/-/g,''));" value="{date('Y-m-d',time()+60*60*24*30)}" />
+				<input type="date" class="inputDate" min="{date('Y-m-d',time())}"  max="{date('Y-m-d',strtotime('+10 years'))}" onchange="$('#stop_date').val($.datepicker.formatDate('yymmdd', new Date(this.value)));" value="{date('Y-m-d',time()+60*60*24*30)}" />
 <script>
 (function($){
 $(function(){
@@ -32,7 +32,7 @@ $(function(){
 			,gotoCurrent: false
 			,yearRange:'-100:+10'
 			, onSelect:function(){
-				$('#stop_date').val(this.value.replace(/-/g,""));
+				$('#stop_date').val($.datepicker.formatDate('yymmdd', $(this).datepicker( "getDate" )));
 			}
 			,defaultDate: new Date("{date('Y-m-d',time()+60*60*24*30)}")
 			,minDate: new Date("{date('Y-m-d',time())}")
@@ -40,6 +40,9 @@ $(function(){
 
 		//if the browser does not support type date input, start datepicker. If it does, brower's UI will show their datepicker.
 		$(".inputDate").datepicker(option);
+	}
+	else
+	{
 	}
 });
 })(jQuery);


### PR DESCRIPTION
XE에서 한국어 언어 파일을 이용해서 사실상 yy-mm-dd 만을 날짜 형식으로 사용했기 때문에, 다국어를 지원하면서 나라마다
다른 형식을 풀어주게 되면, 호환성 문제가 있을 수 있어서 형식을 강제함.